### PR TITLE
Add markdown support to render handler

### DIFF
--- a/pb/paste/handler.py
+++ b/pb/paste/handler.py
@@ -11,18 +11,29 @@
 
 from flask import Response, render_template, url_for, request
 
-from pb.util import publish_parts
+from pb.util import rst, markdown
 
-def render(content):
-    content = render_template("generic.html", content=publish_parts(content), override=request.args.get('css'))
+from mimetypes import add_type
+
+add_type('text/x-markdown', '.md')
+add_type('text/x-rst', '.rst')
+
+mimetypes = {
+    'text/x-markdown': markdown,
+    'text/x-rst': rst
+}
+
+def render(content, mimetype):
+    renderer = mimetypes.get(mimetype, rst)
+    content = render_template("generic.html", content=renderer(content), override=request.args.get('css'))
     return Response(content, mimetype='text/html')
 
 handlers = {
     'r': render
 }
 
-def get(handler, content):
+def get(handler, content, mimetype):
     h = handlers.get(handler)
     if not h:
         return "Invalid handler: '{}'.".format(handler), 400
-    return h(content)
+    return h(content, mimetype)

--- a/pb/paste/views.py
+++ b/pb/paste/views.py
@@ -19,13 +19,17 @@ from pygments.formatters import HtmlFormatter
 from pygments.lexers import get_all_lexers
 
 from pb.paste import model, handler as _handler
-from pb.util import highlight, redirect, request_content, id_url, publish_parts, any_url
+from pb.util import highlight, redirect, request_content, id_url, rst, markdown, any_url
 
 paste = Blueprint('paste', __name__)
 
 @paste.app_template_filter(name='rst')
 def filter_rst(source):
-    return Markup(publish_parts(source))
+    return Markup(rst(source))
+
+@paste.app_template_filter(name='markdown')
+def filter_rst(source):
+    return Markup(markdown(source))
 
 @paste.app_template_global()
 def include_raw(filename):
@@ -153,7 +157,7 @@ def get(sid=None, sha1=None, label=None, lexer=None, handler=None):
     if lexer != None:
         return highlight(content, lexer)
     if handler != None:
-        return _handler.get(handler, content)
+        return _handler.get(handler, content, mimetype)
     if mimetype:
         return Response(content, mimetype=mimetype)
 

--- a/pb/util.py
+++ b/pb/util.py
@@ -21,6 +21,7 @@ from pygments.formatters import HtmlFormatter
 from pygments.util import ClassNotFound
 
 from docutils import core
+from markdown import markdown as _markdown
 
 b66c = string.ascii_uppercase + string.ascii_lowercase + string.digits + '-_~.'
 
@@ -70,7 +71,22 @@ def any_url(paste, filename=None):
         return id_url(label=(paste['label'], filename))
     return id_url(sid=(paste['_id'], filename))
 
-def publish_parts(source):
+def rst(source):
     overrides = {'syntax_highlight': 'short'}
-    parts = core.publish_parts(source, writer_name='html', settings_overrides=overrides)
+    parts = core.publish_parts(source.decode('utf-8'), writer_name='html', settings_overrides=overrides)
     return parts['html_body']
+
+def markdown(source):
+    md = _markdown(source.decode('utf-8'), extensions=[
+        'markdown.extensions.extra',
+        'markdown.extensions.admonition',
+        'markdown.extensions.codehilite',
+        'markdown.extensions.meta',
+        'markdown.extensions.toc',
+        'markdown.extensions.wikilinks'
+    ], extension_configs = {
+        'markdown.extensions.codehilite': {
+            'css_class': 'code'
+        }
+    })
+    return md

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ Pygments>=2.0.1
 requests>=2.5.0
 docutils>=0.12
 pyxdg>=0.25
-pymongo==2.7.2
+pymongo>=2.7.2
+Markdown>=2.6


### PR DESCRIPTION
This uses mimetype extension to disambiugate to the render handler which formatter to use.

Includes a shitload of markdown extensions, namely markdown-extra.

Fixes #102.