### PR TITLE
fix SIDConverter regex

### DIFF
--- a/pb/pb.py
+++ b/pb/pb.py
@@ -29,7 +29,7 @@ class TextResponse(Response):
 class SIDConverter(BaseConverter):
     def __init__(self, map, length):
         super().__init__(map)
-        self.regex = '(([A-Za-z0-9_-~.]{{{}}})(?:[.][^/]*)?)'.format(length)
+        self.regex = '(([A-Za-z0-9_~.-]{{{}}})(?:[.][^/]*)?)'.format(length)
         self.sre = re.compile(self.regex)
         if length % 4 != 0:
             raise NotImplementedError('{} % 4 != 0; kthx'.format(length))


### PR DESCRIPTION
Bug introduced in #104.

Without this, sids that contain `-` would have no matching route. A backslash escape would have also worked, but this is more readable.

Try the original on https://regex101.com/#python