### PR TITLE
add large file/gridfs support

### DIFF
--- a/pb/db.py
+++ b/pb/db.py
@@ -11,6 +11,7 @@
 
 from flask import g, request, current_app
 from pymongo import MongoClient
+from gridfs import GridFS
 
 def get_db():
     con = getattr(g, 'con', None)
@@ -18,6 +19,12 @@ def get_db():
         g.con = con = MongoClient(**current_app.config['MONGO'])
         g.db = con[current_app.config['MONGO_DATABASE']]
     return g.db
+
+def get_fs():
+    fs = getattr(g, 'fs', None)
+    if fs is None:
+        g.fs = GridFS(get_db())
+    return g.fs
 
 def init_db(app):
     @app.teardown_appcontext

--- a/pb/paste/model.py
+++ b/pb/paste/model.py
@@ -14,13 +14,32 @@ from hashlib import sha1
 from datetime import datetime
 
 from pymongo import DESCENDING
+from bson import ObjectId
 
-from pb.db import get_db
+from pb.db import get_db, get_fs
 
-def insert(content, **kwargs):
+def _put(stream):
+    b = stream.read()
+    digest = sha1(b).hexdigest()
+    try:
+        if stream.getbuffer().nbytes > 2 ** 23:
+            b = get_fs().put(b)
+    except AttributeError:
+        # FIXME: what the actual fuck, mitsuhiko?
+        b = get_fs().put(b)
+    return dict(
+        content = b,
+        digest = digest
+    )
+
+def _get(content):
+    if isinstance(content, ObjectId):
+        return get_fs().get(content).read()
+    return content
+
+def insert(stream, **kwargs):
+    kwargs.update(**_put(stream))
     d = dict(
-        content = content,
-        digest = sha1(content).hexdigest(),
         _id = uuid4().hex,
         date = datetime.utcnow(),
         **kwargs
@@ -28,14 +47,11 @@ def insert(content, **kwargs):
     get_db().pastes.insert(d)
     return d
 
-def put(uuid, content):
+def put(uuid, stream):
     return get_db().pastes.update(dict(
         _id = uuid.hex
     ), {
-        '$set': dict(
-            content = content,
-            digest = sha1(content).hexdigest()
-        )
+        '$set': _put(stream)
     })
 
 def delete(uuid):
@@ -43,18 +59,27 @@ def delete(uuid):
         _id = uuid.hex
     ))
 
-def get_digest(content):
-    return get_db().pastes.find(dict(
-        digest = sha1(content).hexdigest()
+def get_digest(stream=None, content=None):
+    paste = get_db().pastes.find(dict(
+        digest = sha1(content if content else stream.read()).hexdigest()
+    ), dict(
+        digest = 1,
+        label = 1,
+        private = 1,
+        _id = 1
     )).sort('date', DESCENDING)
+    if stream:
+        stream.seek(0)
+    return paste
 
 def get_content(**kwargs):
-    return get_db().pastes.find(dict(
+    paste = get_db().pastes.find(dict(
         **kwargs
     ), dict(
         content = 1,
         redirect = 1
     )).sort('date', DESCENDING)
+    return paste
 
 def get_stats():
     return get_db().pastes.find()

--- a/pb/util.py
+++ b/pb/util.py
@@ -11,6 +11,7 @@
 
 import string
 from os import path
+from io import BytesIO
 
 from flask import Response, render_template, current_app, request, url_for
 
@@ -52,10 +53,10 @@ def highlight(content, lexer_name):
 def request_content():
     c = request.form.get('c')
     if c:
-        return c.encode('utf-8'), None
+        return BytesIO(c.encode('utf-8')), None
     fs = request.files.get('c')
     if fs:
-        return fs.stream.read(), fs.filename
+        return fs.stream, fs.filename
 
     return None, None
 


### PR DESCRIPTION
This is all a terrible hack. It also makes obvious a few issues, in
ascending order of severity:

 * multiple sha1.hexdigest() calls for the same content
 * requires at least n bytes memory for request of size n bytes
 * ridiculous numbers of userspace copies

Fixes #103 (after deployment configuration is also adjusted).

You should decide how high we want to go.